### PR TITLE
Fixed retry logic in PG3ConnectionPool>>withConnectionDo:

### DIFF
--- a/repository/PostgresV3.package/PG3AbstractPoolException.class/README.md
+++ b/repository/PostgresV3.package/PG3AbstractPoolException.class/README.md
@@ -1,0 +1,1 @@
+I am the abstract superclass of all exceptions related to the connection pool.

--- a/repository/PostgresV3.package/PG3AbstractPoolException.class/properties.json
+++ b/repository/PostgresV3.package/PG3AbstractPoolException.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "MaxLeske 1/5/2020 18:02",
+	"super" : "Error",
+	"category" : "PostgresV3-Pool-Exceptions",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "PG3AbstractPoolException",
+	"type" : "normal"
+}

--- a/repository/PostgresV3.package/PG3ConnectionCreationError.class/README.md
+++ b/repository/PostgresV3.package/PG3ConnectionCreationError.class/README.md
@@ -1,0 +1,1 @@
+I am signalled when connection creation fails while in #getConnection.

--- a/repository/PostgresV3.package/PG3ConnectionCreationError.class/properties.json
+++ b/repository/PostgresV3.package/PG3ConnectionCreationError.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "MaxLeske 1/5/2020 18:03",
+	"super" : "PG3AbstractPoolException",
+	"category" : "PostgresV3-Pool-Exceptions",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "PG3ConnectionCreationError",
+	"type" : "normal"
+}

--- a/repository/PostgresV3.package/PG3ConnectionPool.class/instance/getConnection.st
+++ b/repository/PostgresV3.package/PG3ConnectionPool.class/instance/getConnection.st
@@ -20,12 +20,11 @@ getConnection
 						usedConnections size < arguments maxConnections ]) ifTrue: [
 							[ freeConnection := self createNewConnection ]
 								on: Error
-								do: [ :error | self log: error messageText ] ] ].
+								do: [ :error | error resignalAs: PG3ConnectionCreationError ] ] ].
 			(freeConnection notNil and: [ 
 				freeConnection isConnected and: [
 					freeConnection isReadyForQuery ] ])
 				ifFalse: [ freeConnection := nil ] ].
 		freeConnection ifNotNil: [ usedConnections add: freeConnection ] ].
-	^freeConnection ifNil: [ 
-		self error: 'Couldn''t get a connection in ', arguments waitTimeout asString, ' milliseconds!'.
-		freeConnection ]
+	^ freeConnection ifNil: [ 
+		PG3ConnectionRetrievalError signal: 'Couldn''t get a connection in ', arguments waitTimeout asString, ' milliseconds!' ]

--- a/repository/PostgresV3.package/PG3ConnectionPool.class/instance/withConnectionDo..st
+++ b/repository/PostgresV3.package/PG3ConnectionPool.class/instance/withConnectionDo..st
@@ -12,7 +12,7 @@ withConnectionDo: aBlock
 				ensure: [
 					connection ifNotNil: [
 						 self releaseConnection: connection ] ] ]
-		on: ConnectionClosed, ConnectionTimedOut 
+		on: ConnectionClosed, ConnectionTimedOut, PG3AbstractPoolException
 		do: [ :err |
 			retriesLeft > 0 ifTrue: [
 				self log: [ 'Error ', (4 - retriesLeft) asString, ': ', err className, ' -> ', err messageText ].

--- a/repository/PostgresV3.package/PG3ConnectionRetrievalError.class/README.md
+++ b/repository/PostgresV3.package/PG3ConnectionRetrievalError.class/README.md
@@ -1,0 +1,3 @@
+I am signalled when no connection can be retrieved while in #getConnection. This can have two reasons:
+1. the maximum number of connections has been reached (see PG3ConnectionPoolArguments)
+2. all connections were busy when performing the first check but there was at least 1 free connection after returning from waiting in the monitor queue.

--- a/repository/PostgresV3.package/PG3ConnectionRetrievalError.class/properties.json
+++ b/repository/PostgresV3.package/PG3ConnectionRetrievalError.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "MaxLeske 1/5/2020 18:06",
+	"super" : "PG3AbstractPoolException",
+	"category" : "PostgresV3-Pool-Exceptions",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "PG3ConnectionRetrievalError",
+	"type" : "normal"
+}

--- a/repository/PostgresV3.package/monticello.meta/categories.st
+++ b/repository/PostgresV3.package/monticello.meta/categories.st
@@ -1,8 +1,9 @@
 SystemOrganization addCategory: #PostgresV3!
-SystemOrganization addCategory: 'PostgresV3-CodeMirror'!
-SystemOrganization addCategory: 'PostgresV3-Core'!
-SystemOrganization addCategory: 'PostgresV3-Core-Messages'!
-SystemOrganization addCategory: 'PostgresV3-Objects'!
-SystemOrganization addCategory: 'PostgresV3-Pool'!
-SystemOrganization addCategory: 'PostgresV3-Tests-Core'!
-SystemOrganization addCategory: 'PostgresV3-Tests-Pool'!
+SystemOrganization addCategory: #'PostgresV3-CodeMirror'!
+SystemOrganization addCategory: #'PostgresV3-Core'!
+SystemOrganization addCategory: #'PostgresV3-Core-Messages'!
+SystemOrganization addCategory: #'PostgresV3-Objects'!
+SystemOrganization addCategory: #'PostgresV3-Pool'!
+SystemOrganization addCategory: #'PostgresV3-Pool-Exceptions'!
+SystemOrganization addCategory: #'PostgresV3-Tests-Core'!
+SystemOrganization addCategory: #'PostgresV3-Tests-Pool'!


### PR DESCRIPTION
The retry logic did not work for connection creation errors and a race condition where `freeConnections` is empty at the first check but not empty after returning from waiting in the monitor queue.

In addition, this change introduces real exceptions which facilitates error handling in application code.